### PR TITLE
chore: Specify a list of published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "directories": {
     "test": "tests"
   },
+  "files": [
+    "index.js",
+    "format-error.js",
+    "format-success.js"
+  ],
   "scripts": {
     "test": "node_modules/mocha/bin/mocha tests/test.js"
   },


### PR DESCRIPTION
Limit the list of published files to `index.js`, `format-error.js`, and `format-success.js` (in addition to the list of [always-included files](https://docs.npmjs.com/files/package.json#files) `LICENSE`, `package.json`, and `README.md`).

Here is how the package will look like now:
```
$ npm pack
npm notice
npm notice 📦  @gh-conf/gh-conf-response@1.0.2
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 255B  format-error.js
npm notice 265B  format-success.js
npm notice 153B  index.js
npm notice 824B  package.json
npm notice 2.7kB README.md
npm notice === Tarball Details ===
npm notice name:          @gh-conf/gh-conf-response
npm notice version:       1.0.2
npm notice filename:      gh-conf-gh-conf-response-1.0.2.tgz
npm notice package size:  2.3 kB
npm notice unpacked size: 5.3 kB
npm notice shasum:        fc50491c38b34b0877464af203c5b9b74e52793c
npm notice integrity:     sha512-YwPeFf7hC3yU/[...]LY9DoDbpPQvdQ==
npm notice total files:   6
npm notice
```

Fixes https://github.com/gh-conf/gh-conf-response/issues/5